### PR TITLE
chore:  restrict fastmcp version to <2.7.0 for compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "ipython",
     "jupyter_core",
     "paramiko>=2.8.0",
-    "fastmcp>=2.3.4",
+    "fastmcp>=2.3.4,<2.7.0",
     "uvicorn>=0.20.0",
     "starlette>=0.25.0"
 ]


### PR DESCRIPTION
The server stopped working for me after fastmcp was updated to 2.7.0.  I got it working again by using fastmcp 2.6.1.