### PR TITLE
fix: add pydantic version constraint to prevent 2.12.0+ incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-11-07
+### Fixed
+- Added pydantic version constraint (`pydantic>=2.0.0,<2.12.0`) to prevent installation failures with pydantic 2.12.0+ (resolves [issue #19](https://github.com/jbeno/cursor-notebook-mcp/issues/19))
+- Pydantic 2.12.0 introduced stricter validation that is incompatible with the current version of fastmcp dependency
+
 ## [0.3.1] - 2025-07-15
 ### Fixed
 - Compatibility with breaking changes introduced in FastMCP 2.7.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This MCP server uses the `nbformat` library to safely manipulate notebook struct
 
 ## Latest Version
 
-**Current Version:** `0.3.1` - See the [CHANGELOG.md](CHANGELOG.md) for details on recent changes. Key additions include SFTP support, Streamable HTTP transport, and new tools like `notebook_edit_cell_output`, `notebook_bulk_add_cells`, and `notebook_get_server_path_context` to improve notebook editing and path handling.
+**Current Version:** `0.3.2` - See the [CHANGELOG.md](CHANGELOG.md) for details on recent changes. This version includes a fix for pydantic 2.12.0+ compatibility. Previous additions include SFTP support, Streamable HTTP transport, and new tools like `notebook_edit_cell_output`, `notebook_bulk_add_cells`, and `notebook_get_server_path_context` to improve notebook editing and path handling.
 
 ## Video Walkthrough
 
@@ -75,7 +75,7 @@ This project has both Python package dependencies and potentially external syste
 ### Python Dependencies
 
 *   **Python Version:** 3.10+
-*   **Core:** `mcp>=0.1.0`, `nbformat>=5.0`, `nbconvert>=6.0`, `ipython`, `jupyter_core`, `paramiko>=2.8.0`, `fastmcp>=2.7.0,<2.11`, `uvicorn>=0.20.0`, `starlette>=0.25.0`. These are installed automatically when you install `cursor-notebook-mcp` and provide support for all transport modes (stdio, Streamable HTTP, SSE).
+*   **Core:** `mcp>=0.1.0`, `nbformat>=5.0`, `nbconvert>=6.0`, `ipython`, `jupyter_core`, `paramiko>=2.8.0`, `fastmcp>=2.7.0,<2.11`, `pydantic>=2.0.0,<2.12.0`, `uvicorn>=0.20.0`, `starlette>=0.25.0`. These are installed automatically when you install `cursor-notebook-mcp` and provide support for all transport modes (stdio, Streamable HTTP, SSE).
 *   **Optional - Development/Testing:** `pytest>=7.0`, `pytest-asyncio>=0.18`, `pytest-cov`, `pytest-timeout>=2.0.0`, `coveralls`. Install via `pip install -e ".[dev]"` from source checkout.
 
 ### External System Dependencies (Optional)

--- a/cursor_notebook_mcp/__init__.py
+++ b/cursor_notebook_mcp/__init__.py
@@ -5,6 +5,6 @@ This package provides a Model Context Protocol (MCP) server that allows
 AI agents within Cursor to interact with Jupyter Notebook (.ipynb) files.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 # Components are imported directly where needed (e.g., in notebook_mcp_server.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cursor-notebook-mcp"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
   { name="Jim Beno", email="jim@jimbeno.net" },
 ]
@@ -39,6 +39,7 @@ dependencies = [
     "jupyter_core",
     "paramiko>=2.8.0",
     "fastmcp>=2.7.0,<2.11",
+    "pydantic>=2.0.0,<2.12.0",
     "uvicorn>=0.20.0",
     "starlette>=0.25.0"
 ]


### PR DESCRIPTION
Resolves #19

- Added pydantic>=2.0.0,<2.12.0 constraint to dependencies
- Pydantic 2.12.0 introduced stricter validation incompatible with fastmcp
- Bumped version to 0.3.2
- Updated CHANGELOG.md and README.md with version and dependency info